### PR TITLE
Implemented updated styles to catch up with TailwindCSS v4 migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
         "": {
             "devDependencies": {
                 "@inertiajs/vue3": "^2.0.0",
-                "@tailwindcss/forms": "^0.5.3",
-                "@tailwindcss/postcss": "^4.1.12",
-                "@tailwindcss/vite": "^4.1.12",
+                "@tailwindcss/forms": "^0.5.10",
+                "@tailwindcss/postcss": "^4.1.13",
+                "@tailwindcss/vite": "^4.1.13",
                 "@vitejs/plugin-vue": "^6.0.1",
                 "autoprefixer": "^10.4.12",
                 "axios": "^1.6.4",
@@ -16,7 +16,7 @@
                 "laravel-vite-plugin": "^2.0.1",
                 "postcss": "^8.4.31",
                 "sweetalert2": "^11.15.10",
-                "tailwindcss": "^4.1.12",
+                "tailwindcss": "^4.1.13",
                 "vite": "^7.1.3",
                 "vue": "^3.4.0",
                 "vue3-dropzone": "^2.2.1"
@@ -56,13 +56,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -72,9 +72,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -528,9 +528,9 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.1.3.tgz",
-            "integrity": "sha512-X8E5sPF0MF69+2kxOHuBqW06Rr/VD51Je37JY8bi5SCoi9wTpzmaurpDDIftnbfCJGYupFL1jky7DjEpD+6ufg==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.1.6.tgz",
+            "integrity": "sha512-PvY3QJecHt/Z+X+C+jJOHnBGxvi6YNuX3tLY0oXA2yC8aQZeUHnIoWnQdKgc0KA0CNj3b3sZSxm2ZQs9nMY7/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -541,13 +541,13 @@
             }
         },
         "node_modules/@inertiajs/vue3": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-2.1.3.tgz",
-            "integrity": "sha512-n2SoIb6L9pHPw8vMZ+wM8KxFv1GzO04cUG5OxUE3VqpFlqHK+SX/nZIG0xXR7TkwwtlK9IxxeuaIDY6gFOvCqQ==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-2.1.6.tgz",
+            "integrity": "sha512-r2tCjCe8kSPaEsbZFphKWnKZQ2/2ZItvrB3HWYCwl0ZS0wY396IsZcCpeJKFhF1xCoAnNYpfZo10dvcRmCipfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "2.1.3",
+                "@inertiajs/core": "2.1.6",
                 "@types/lodash-es": "^4.17.12",
                 "lodash-es": "^4.17.21"
             },
@@ -608,9 +608,9 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.30",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-            "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -626,9 +626,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
-            "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+            "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
             "cpu": [
                 "arm"
             ],
@@ -640,9 +640,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
-            "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+            "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
             "cpu": [
                 "arm64"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
-            "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+            "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -668,9 +668,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
-            "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+            "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
             "cpu": [
                 "x64"
             ],
@@ -682,9 +682,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
-            "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+            "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
-            "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+            "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
             "cpu": [
                 "x64"
             ],
@@ -710,9 +710,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
-            "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+            "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
             "cpu": [
                 "arm"
             ],
@@ -724,9 +724,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
-            "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+            "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
             "cpu": [
                 "arm"
             ],
@@ -738,9 +738,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
-            "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+            "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
             "cpu": [
                 "arm64"
             ],
@@ -752,9 +752,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
-            "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+            "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
             "cpu": [
                 "arm64"
             ],
@@ -765,10 +765,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
-            "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+            "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
             "cpu": [
                 "loong64"
             ],
@@ -780,9 +780,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
-            "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+            "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
             "cpu": [
                 "ppc64"
             ],
@@ -794,9 +794,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
-            "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+            "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -808,9 +808,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
-            "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+            "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
             "cpu": [
                 "riscv64"
             ],
@@ -822,9 +822,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
-            "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+            "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
             "cpu": [
                 "s390x"
             ],
@@ -836,9 +836,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
-            "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+            "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
             "cpu": [
                 "x64"
             ],
@@ -850,9 +850,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
-            "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+            "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
             "cpu": [
                 "x64"
             ],
@@ -863,10 +863,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+            "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
-            "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+            "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
             "cpu": [
                 "arm64"
             ],
@@ -878,9 +892,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
-            "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+            "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
             "cpu": [
                 "ia32"
             ],
@@ -892,9 +906,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
-            "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+            "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
             "cpu": [
                 "x64"
             ],
@@ -919,9 +933,9 @@
             }
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.12.tgz",
-            "integrity": "sha512-3hm9brwvQkZFe++SBt+oLjo4OLDtkvlE8q2WalaD/7QWaeM7KEJbAiY/LJZUaCs7Xa8aUu4xy3uoyX4q54UVdQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
+            "integrity": "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -929,15 +943,15 @@
                 "enhanced-resolve": "^5.18.3",
                 "jiti": "^2.5.1",
                 "lightningcss": "1.30.1",
-                "magic-string": "^0.30.17",
+                "magic-string": "^0.30.18",
                 "source-map-js": "^1.2.1",
-                "tailwindcss": "4.1.12"
+                "tailwindcss": "4.1.13"
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.12.tgz",
-            "integrity": "sha512-gM5EoKHW/ukmlEtphNwaGx45fGoEmP10v51t9unv55voWh6WrOL19hfuIdo2FjxIaZzw776/BUQg7Pck++cIVw==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.13.tgz",
+            "integrity": "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -949,24 +963,24 @@
                 "node": ">= 10"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.1.12",
-                "@tailwindcss/oxide-darwin-arm64": "4.1.12",
-                "@tailwindcss/oxide-darwin-x64": "4.1.12",
-                "@tailwindcss/oxide-freebsd-x64": "4.1.12",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.12",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.12",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.1.12",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.1.12",
-                "@tailwindcss/oxide-linux-x64-musl": "4.1.12",
-                "@tailwindcss/oxide-wasm32-wasi": "4.1.12",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.12",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.1.12"
+                "@tailwindcss/oxide-android-arm64": "4.1.13",
+                "@tailwindcss/oxide-darwin-arm64": "4.1.13",
+                "@tailwindcss/oxide-darwin-x64": "4.1.13",
+                "@tailwindcss/oxide-freebsd-x64": "4.1.13",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.13",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.1.13",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.1.13",
+                "@tailwindcss/oxide-linux-x64-musl": "4.1.13",
+                "@tailwindcss/oxide-wasm32-wasi": "4.1.13",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.13",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.1.13"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.12.tgz",
-            "integrity": "sha512-oNY5pq+1gc4T6QVTsZKwZaGpBb2N1H1fsc1GD4o7yinFySqIuRZ2E4NvGasWc6PhYJwGK2+5YT1f9Tp80zUQZQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.13.tgz",
+            "integrity": "sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==",
             "cpu": [
                 "arm64"
             ],
@@ -981,9 +995,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.12.tgz",
-            "integrity": "sha512-cq1qmq2HEtDV9HvZlTtrj671mCdGB93bVY6J29mwCyaMYCP/JaUBXxrQQQm7Qn33AXXASPUb2HFZlWiiHWFytw==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.13.tgz",
+            "integrity": "sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==",
             "cpu": [
                 "arm64"
             ],
@@ -998,9 +1012,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.12.tgz",
-            "integrity": "sha512-6UCsIeFUcBfpangqlXay9Ffty9XhFH1QuUFn0WV83W8lGdX8cD5/+2ONLluALJD5+yJ7k8mVtwy3zMZmzEfbLg==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.13.tgz",
+            "integrity": "sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==",
             "cpu": [
                 "x64"
             ],
@@ -1015,9 +1029,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.12.tgz",
-            "integrity": "sha512-JOH/f7j6+nYXIrHobRYCtoArJdMJh5zy5lr0FV0Qu47MID/vqJAY3r/OElPzx1C/wdT1uS7cPq+xdYYelny1ww==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.13.tgz",
+            "integrity": "sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==",
             "cpu": [
                 "x64"
             ],
@@ -1032,9 +1046,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.12.tgz",
-            "integrity": "sha512-v4Ghvi9AU1SYgGr3/j38PD8PEe6bRfTnNSUE3YCMIRrrNigCFtHZ2TCm8142X8fcSqHBZBceDx+JlFJEfNg5zQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.13.tgz",
+            "integrity": "sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==",
             "cpu": [
                 "arm"
             ],
@@ -1049,9 +1063,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.12.tgz",
-            "integrity": "sha512-YP5s1LmetL9UsvVAKusHSyPlzSRqYyRB0f+Kl/xcYQSPLEw/BvGfxzbH+ihUciePDjiXwHh+p+qbSP3SlJw+6g==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.13.tgz",
+            "integrity": "sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1066,9 +1080,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.12.tgz",
-            "integrity": "sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.13.tgz",
+            "integrity": "sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==",
             "cpu": [
                 "arm64"
             ],
@@ -1083,9 +1097,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.12.tgz",
-            "integrity": "sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.13.tgz",
+            "integrity": "sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==",
             "cpu": [
                 "x64"
             ],
@@ -1100,9 +1114,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.12.tgz",
-            "integrity": "sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.13.tgz",
+            "integrity": "sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==",
             "cpu": [
                 "x64"
             ],
@@ -1117,9 +1131,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.12.tgz",
-            "integrity": "sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.13.tgz",
+            "integrity": "sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==",
             "bundleDependencies": [
                 "@napi-rs/wasm-runtime",
                 "@emnapi/core",
@@ -1147,9 +1161,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",
-            "integrity": "sha512-iGLyD/cVP724+FGtMWslhcFyg4xyYyM+5F4hGvKA7eifPkXHRAUDFaimu53fpNg9X8dfP75pXx/zFt/jlNF+lg==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.13.tgz",
+            "integrity": "sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==",
             "cpu": [
                 "arm64"
             ],
@@ -1164,9 +1178,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.12.tgz",
-            "integrity": "sha512-NKIh5rzw6CpEodv/++r0hGLlfgT/gFN+5WNdZtvh6wpU2BpGNgdjvj6H2oFc8nCM839QM1YOhjpgbAONUb4IxA==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.13.tgz",
+            "integrity": "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==",
             "cpu": [
                 "x64"
             ],
@@ -1181,29 +1195,29 @@
             }
         },
         "node_modules/@tailwindcss/postcss": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.12.tgz",
-            "integrity": "sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.13.tgz",
+            "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
-                "@tailwindcss/node": "4.1.12",
-                "@tailwindcss/oxide": "4.1.12",
+                "@tailwindcss/node": "4.1.13",
+                "@tailwindcss/oxide": "4.1.13",
                 "postcss": "^8.4.41",
-                "tailwindcss": "4.1.12"
+                "tailwindcss": "4.1.13"
             }
         },
         "node_modules/@tailwindcss/vite": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.12.tgz",
-            "integrity": "sha512-4pt0AMFDx7gzIrAOIYgYP0KCBuKWqyW8ayrdiLEjoJTT4pKTjrzG/e4uzWtTLDziC+66R9wbUqZBccJalSE5vQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.13.tgz",
+            "integrity": "sha512-0PmqLQ010N58SbMTJ7BVJ4I2xopiQn/5i6nlb4JmxzQf8zcS5+m2Cv6tqh+sfDwtIdjoEnOvwsGQ1hkUi8QEHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tailwindcss/node": "4.1.12",
-                "@tailwindcss/oxide": "4.1.12",
-                "tailwindcss": "4.1.12"
+                "@tailwindcss/node": "4.1.13",
+                "@tailwindcss/oxide": "4.1.13",
+                "tailwindcss": "4.1.13"
             },
             "peerDependencies": {
                 "vite": "^5.2.0 || ^6 || ^7"
@@ -1251,111 +1265,111 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.20.tgz",
-            "integrity": "sha512-8TWXUyiqFd3GmP4JTX9hbiTFRwYHgVL/vr3cqhr4YQ258+9FADwvj7golk2sWNGHR67QgmCZ8gz80nQcMokhwg==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
+            "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.3",
-                "@vue/shared": "3.5.20",
+                "@vue/shared": "3.5.21",
                 "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.20.tgz",
-            "integrity": "sha512-whB44M59XKjqUEYOMPYU0ijUV0G+4fdrHVKDe32abNdX/kJe1NUEMqsi4cwzXa9kyM9w5S8WqFsrfo1ogtBZGQ==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
+            "integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.20",
-                "@vue/shared": "3.5.20"
+                "@vue/compiler-core": "3.5.21",
+                "@vue/shared": "3.5.21"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.20.tgz",
-            "integrity": "sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
+            "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.3",
-                "@vue/compiler-core": "3.5.20",
-                "@vue/compiler-dom": "3.5.20",
-                "@vue/compiler-ssr": "3.5.20",
-                "@vue/shared": "3.5.20",
+                "@vue/compiler-core": "3.5.21",
+                "@vue/compiler-dom": "3.5.21",
+                "@vue/compiler-ssr": "3.5.21",
+                "@vue/shared": "3.5.21",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.17",
+                "magic-string": "^0.30.18",
                 "postcss": "^8.5.6",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.20.tgz",
-            "integrity": "sha512-RSl5XAMc5YFUXpDQi+UQDdVjH9FnEpLDHIALg5J0ITHxkEzJ8uQLlo7CIbjPYqmZtt6w0TsIPbo1izYXwDG7JA==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
+            "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.20",
-                "@vue/shared": "3.5.20"
+                "@vue/compiler-dom": "3.5.21",
+                "@vue/shared": "3.5.21"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.20.tgz",
-            "integrity": "sha512-hS8l8x4cl1fmZpSQX/NXlqWKARqEsNmfkwOIYqtR2F616NGfsLUm0G6FQBK6uDKUCVyi1YOL8Xmt/RkZcd/jYQ==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
+            "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.20"
+                "@vue/shared": "3.5.21"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.20.tgz",
-            "integrity": "sha512-vyQRiH5uSZlOa+4I/t4Qw/SsD/gbth0SW2J7oMeVlMFMAmsG1rwDD6ok0VMmjXY3eI0iHNSSOBilEDW98PLRKw==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
+            "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.20",
-                "@vue/shared": "3.5.20"
+                "@vue/reactivity": "3.5.21",
+                "@vue/shared": "3.5.21"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.20.tgz",
-            "integrity": "sha512-KBHzPld/Djw3im0CQ7tGCpgRedryIn4CcAl047EhFTCCPT2xFf4e8j6WeKLgEEoqPSl9TYqShc3Q6tpWpz/Xgw==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
+            "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.20",
-                "@vue/runtime-core": "3.5.20",
-                "@vue/shared": "3.5.20",
+                "@vue/reactivity": "3.5.21",
+                "@vue/runtime-core": "3.5.21",
+                "@vue/shared": "3.5.21",
                 "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.20.tgz",
-            "integrity": "sha512-HthAS0lZJDH21HFJBVNTtx+ULcIbJQRpjSVomVjfyPkFSpCwvsPTA+jIzOaUm3Hrqx36ozBHePztQFg6pj5aKg==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
+            "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.20",
-                "@vue/shared": "3.5.20"
+                "@vue/compiler-ssr": "3.5.21",
+                "@vue/shared": "3.5.21"
             },
             "peerDependencies": {
-                "vue": "3.5.20"
+                "vue": "3.5.21"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.20.tgz",
-            "integrity": "sha512-SoRGP596KU/ig6TfgkCMbXkr4YJ91n/QSdMuqeP5r3hVIYA3CPHUBCc7Skak0EAKV+5lL4KyIh61VA/pK1CIAA==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
+            "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1415,9 +1429,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1426,10 +1440,20 @@
                 "proxy-from-env": "^1.1.0"
             }
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
+            "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
         "node_modules/browserslist": {
-            "version": "4.25.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
-            "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.0.tgz",
+            "integrity": "sha512-P9go2WrP9FiPwLv3zqRD/Uoxo0RSHjzFCiQz7d4vbmwNqQFo9T9WCeP/Qn5EbcKQY6DBbkxEXNcpJOmncNrb7A==",
             "dev": true,
             "funding": [
                 {
@@ -1447,9 +1471,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001735",
-                "electron-to-chromium": "^1.5.204",
-                "node-releases": "^2.0.19",
+                "baseline-browser-mapping": "^2.8.2",
+                "caniuse-lite": "^1.0.30001741",
+                "electron-to-chromium": "^1.5.218",
+                "node-releases": "^2.0.21",
                 "update-browserslist-db": "^1.1.3"
             },
             "bin": {
@@ -1491,9 +1516,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001737",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-            "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
             "dev": true,
             "funding": [
                 {
@@ -1542,9 +1567,9 @@
             "license": "MIT"
         },
         "node_modules/dayjs": {
-            "version": "1.11.14",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.14.tgz",
-            "integrity": "sha512-E8fIdSxUlyqSA8XYGnNa3IkIzxtEmFjI+JU/6ic0P1zmSqyL6HyG5jHnpPjRguDNiaHLpfvHKWFiohNsJLqcJQ==",
+            "version": "1.11.18",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+            "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1559,9 +1584,9 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+            "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1584,9 +1609,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.211",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-            "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+            "version": "1.5.218",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
+            "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
             "dev": true,
             "license": "ISC"
         },
@@ -2211,9 +2236,9 @@
             "license": "MIT"
         },
         "node_modules/magic-string": {
-            "version": "0.30.18",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-            "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+            "version": "0.30.19",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+            "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2322,9 +2347,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+            "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
             "dev": true,
             "license": "MIT"
         },
@@ -2431,9 +2456,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
-            "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+            "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2447,26 +2472,27 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.49.0",
-                "@rollup/rollup-android-arm64": "4.49.0",
-                "@rollup/rollup-darwin-arm64": "4.49.0",
-                "@rollup/rollup-darwin-x64": "4.49.0",
-                "@rollup/rollup-freebsd-arm64": "4.49.0",
-                "@rollup/rollup-freebsd-x64": "4.49.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.49.0",
-                "@rollup/rollup-linux-arm64-musl": "4.49.0",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.49.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.49.0",
-                "@rollup/rollup-linux-x64-gnu": "4.49.0",
-                "@rollup/rollup-linux-x64-musl": "4.49.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.49.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.49.0",
-                "@rollup/rollup-win32-x64-msvc": "4.49.0",
+                "@rollup/rollup-android-arm-eabi": "4.50.2",
+                "@rollup/rollup-android-arm64": "4.50.2",
+                "@rollup/rollup-darwin-arm64": "4.50.2",
+                "@rollup/rollup-darwin-x64": "4.50.2",
+                "@rollup/rollup-freebsd-arm64": "4.50.2",
+                "@rollup/rollup-freebsd-x64": "4.50.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+                "@rollup/rollup-linux-arm64-musl": "4.50.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+                "@rollup/rollup-linux-x64-gnu": "4.50.2",
+                "@rollup/rollup-linux-x64-musl": "4.50.2",
+                "@rollup/rollup-openharmony-arm64": "4.50.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+                "@rollup/rollup-win32-x64-msvc": "4.50.2",
                 "fsevents": "~2.3.2"
             }
         },
@@ -2557,9 +2583,9 @@
             }
         },
         "node_modules/sweetalert2": {
-            "version": "11.22.5",
-            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.22.5.tgz",
-            "integrity": "sha512-k9gb2M0n4b830FaWDmqaFQULIRvKixTbJOBkTN5KwRNIT8UxjGxusC9g67cj8sCxkJb9nVy2+PgyVd7vYK7cug==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.23.0.tgz",
+            "integrity": "sha512-cKzzbC3C1sIs7o9XAMw4E8F9kBtGXsBDUsd2JZ8JM/dqa+nzWwSGM+9LLYILZWzWHzX9W+HJNHyBlbHPVS/krw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2568,9 +2594,9 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
-            "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+            "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
             "dev": true,
             "license": "MIT"
         },
@@ -2607,14 +2633,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -2662,9 +2688,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-            "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+            "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2673,7 +2699,7 @@
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
                 "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.14"
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -2761,17 +2787,17 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.20.tgz",
-            "integrity": "sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
+            "integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.20",
-                "@vue/compiler-sfc": "3.5.20",
-                "@vue/runtime-dom": "3.5.20",
-                "@vue/server-renderer": "3.5.20",
-                "@vue/shared": "3.5.20"
+                "@vue/compiler-dom": "3.5.21",
+                "@vue/compiler-sfc": "3.5.21",
+                "@vue/runtime-dom": "3.5.21",
+                "@vue/server-renderer": "3.5.21",
+                "@vue/shared": "3.5.21"
             },
             "peerDependencies": {
                 "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     },
     "devDependencies": {
         "@inertiajs/vue3": "^2.0.0",
-        "@tailwindcss/forms": "^0.5.3",
-        "@tailwindcss/postcss": "^4.1.12",
-        "@tailwindcss/vite": "^4.1.12",
+        "@tailwindcss/forms": "^0.5.10",
+        "@tailwindcss/postcss": "^4.1.13",
+        "@tailwindcss/vite": "^4.1.13",
         "@vitejs/plugin-vue": "^6.0.1",
         "autoprefixer": "^10.4.12",
         "axios": "^1.6.4",
@@ -17,7 +17,7 @@
         "laravel-vite-plugin": "^2.0.1",
         "postcss": "^8.4.31",
         "sweetalert2": "^11.15.10",
-        "tailwindcss": "^4.1.12",
+        "tailwindcss": "^4.1.13",
         "vite": "^7.1.3",
         "vue": "^3.4.0",
         "vue3-dropzone": "^2.2.1"

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,21 @@
+
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@200..700&display=swap');
 @import "tailwindcss";
+
+@layer base {
+    input[type='text'],
+    input[type='email'],
+    input[type='password'],
+    select,
+    textarea {
+        @apply px-3 py-2 rounded-md border border-gray-300;
+    }
+
+    *, ::before, ::after {
+        @apply border-gray-200;
+    }
+}
+
 
 body{
     font-family: "Open Sans", sans-serif;
@@ -7,7 +23,7 @@ body{
 }
 
 a {
-    @apply hover:underline ;
+    @apply hover:underline;
 }
 
 h2 {

--- a/resources/js/Components/Dropdown.vue
+++ b/resources/js/Components/Dropdown.vue
@@ -68,7 +68,7 @@ const open = ref(false);
                 style="display: none"
                 @click="open = false"
             >
-                <div class="rounded-md ring-1 ring-black ring-opacity-5" :class="contentClasses">
+                <div class="rounded-md ring ring-black/5" :class="contentClasses">
                     <slot name="content" />
                 </div>
             </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -101,14 +101,14 @@ const showingNavigationDropdown = ref(false);
                                             Audit Trail
                                         </DropdownLink>
 
-                                        <hr>
+                                        <hr class="text-gray-200">
                                         <div class="px-4 opacity-50 text-xs mt-4">
                                             Switch team
                                         </div>
                                         <DropdownLink :href="'/switch-team/' + userTeam.team_id" v-for="userTeam in usePage().props.auth.availableTeams">
                                             {{ userTeam.team.name }}
                                         </DropdownLink>
-                                        <hr>
+                                        <hr class="text-gray-200">
 
 
                                         <DropdownLink :href="route('logout')" method="post" as="button">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,9 +11,16 @@ export default {
     ],
 
     theme: {
+        borderColor: {
+            DEFAULT: '#e5e7eb', // Tailwind gray.200
+        },
         extend: {
             fontFamily: {
                 sans: ['Oswald', ...defaultTheme.fontFamily.sans],
+            },
+
+            colors: {
+                transparent: "transparent",
             },
         },
     },


### PR DESCRIPTION
In a previous pull request, we updated the Tailwind CSS dependency from version 3 to version 4. This introduced a few changes to the defaults within the base CSS system. This pull request reverts some of these changes in our app.css file and in some of the Vue 3 components. There may be more styling updates that need to be done, as we might not have caught them all.