### PR TITLE
Added a check & response for expired voucher in validation endpoint

### DIFF
--- a/app/Enums/ApiResponse.php
+++ b/app/Enums/ApiResponse.php
@@ -32,7 +32,7 @@ enum ApiResponse: string
     case RESPONSE_REDEMPTION_FAILED_VOUCHER_ALREADY_FULLY_REDEEMED      = 'This voucher has already been fully redeemed, no redemption made this time.';
     case RESPONSE_REDEMPTION_FAILED_REQUESTED_AMOUNT_TOO_HIGH           = 'Requested amount is greater than voucher value remaining, no redemption made this time.';
     case RESPONSE_REDEMPTION_FAILED_TOO_MANY_ATTEMPTS                   = 'Too many redemption attempts, please wait.';
-    case RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED                     = 'This voucher has expired.';
+    case RESPONSE_VOUCHER_EXPIRED                                       = 'This voucher has expired.';
     case RESPONSE_REDEMPTION_LIVE_REDEMPTION                            = 'Please provide the customer with their goods / services to the value of XXX.';
     case RESPONSE_REDEMPTION_TEST_REDEMPTION                            = 'This was a test redemption. Do NOT provide the person with goods or services.';
     case RESPONSE_REDEMPTION_SUCCESSFUL                                 = 'Redemption successful.';

--- a/app/Http/Controllers/Api/V1/ApiVoucherRedemptionsController.php
+++ b/app/Http/Controllers/Api/V1/ApiVoucherRedemptionsController.php
@@ -166,7 +166,7 @@ class ApiVoucherRedemptionsController extends Controller
             if (!is_null($voucher->expires_at)) {
                 if ($voucher->expires_at <= now()) {
                     $this->responseCode = 400;
-                    $this->message      = ApiResponse::RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED->value;
+                    $this->message      = ApiResponse::RESPONSE_VOUCHER_EXPIRED->value;
 
                     return $this->respond();
                 }

--- a/app/Http/Controllers/Api/V1/ApiVoucherValidationController.php
+++ b/app/Http/Controllers/Api/V1/ApiVoucherValidationController.php
@@ -145,6 +145,15 @@ class ApiVoucherValidationController extends Controller
                 ]
             );
 
+            if (!is_null($voucher->expires_at)) {
+                if ($voucher->expires_at <= now()) {
+                    $this->responseCode = 409;
+                    $this->message      = ApiResponse::RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED->value;
+
+                    return $this->respond();
+                }
+            }
+
             /**
              * At this point everything checks out, we can return the voucher details
              */

--- a/app/Http/Controllers/Api/V1/ApiVoucherValidationController.php
+++ b/app/Http/Controllers/Api/V1/ApiVoucherValidationController.php
@@ -148,7 +148,7 @@ class ApiVoucherValidationController extends Controller
             if (!is_null($voucher->expires_at)) {
                 if ($voucher->expires_at <= now()) {
                     $this->responseCode = 409;
-                    $this->message      = ApiResponse::RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED->value;
+                    $this->message      = ApiResponse::RESPONSE_VOUCHER_EXPIRED->value;
 
                     return $this->respond();
                 }

--- a/tests/Feature/API/App/VoucherRedemption/VoucherRedemptionPostTest.php
+++ b/tests/Feature/API/App/VoucherRedemption/VoucherRedemptionPostTest.php
@@ -375,6 +375,6 @@ class VoucherRedemptionPostTest extends BaseAPITestCase
         $response->assertStatus(400);
 
         $responseObject = json_decode($response->getContent(), false);
-        $this->assertSame(ApiResponse::RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED->value, $responseObject->meta->message);
+        $this->assertSame(ApiResponse::RESPONSE_VOUCHER_EXPIRED->value, $responseObject->meta->message);
     }
 }

--- a/tests/Feature/API/App/VoucherValidation/VoucherValidationPostTest.php
+++ b/tests/Feature/API/App/VoucherValidation/VoucherValidationPostTest.php
@@ -206,7 +206,7 @@ class VoucherValidationPostTest extends BaseAPITestCase
          * Assert status code & message are expected
          */
         $response->assertStatus(409);
-        $this->assertEquals($responseObject->meta->message, ApiResponse::RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED->value);
+        $this->assertEquals($responseObject->meta->message, ApiResponse::RESPONSE_VOUCHER_EXPIRED->value);
     }
 
     #[Test]

--- a/tests/Feature/API/App/VoucherValidation/VoucherValidationPostTest.php
+++ b/tests/Feature/API/App/VoucherValidation/VoucherValidationPostTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\API\App\VoucherValidation;
 
+use App\Enums\ApiResponse;
 use App\Models\Voucher;
 use App\Models\VoucherSet;
 use App\Models\VoucherSetMerchantTeam;
@@ -15,36 +16,6 @@ class VoucherValidationPostTest extends BaseAPITestCase
     use RefreshDatabase;
 
     protected string $endPoint = '/voucher-validation';
-
-    #[Test]
-    public function itFailsIfVoucherIdentifierIsWrong()
-    {
-
-        $this->user = $this->createUserWithTeam();
-
-        Sanctum::actingAs(
-            $this->user
-        );
-
-        $voucherSet         = VoucherSet::factory()->createQuietly();
-        $voucherSetMerchant = VoucherSetMerchantTeam::factory()->createQuietly(
-            [
-                'voucher_set_id'   => $voucherSet->id,
-                'merchant_team_id' => $this->user->current_team_id,
-            ]
-        );
-
-        $payload = [
-            'type'  => 'voucher_id',
-            'value' => 'INCORRECT VALUE',
-        ];
-
-        $data = json_encode($payload);
-
-        $response = $this->postJson($this->apiRoot . $this->endPoint, $payload);
-
-        $response->assertStatus(404);
-    }
 
     #[Test]
     public function itCanValidateVoucherUsingId()
@@ -165,6 +136,77 @@ class VoucherValidationPostTest extends BaseAPITestCase
         $this->assertEquals($voucher->id, $responseObj->data->id);
         $this->assertObjectNotHasProperty(propertyName: 'created_by_team_id', object: $responseObj->data);
         $this->assertObjectNotHasProperty(propertyName: 'allocated_to_service_team_id', object: $responseObj->data);
+    }
+
+    #[Test]
+    public function itFailsIfVoucherIdentifierIsWrong()
+    {
+
+        $this->user = $this->createUserWithTeam();
+
+        Sanctum::actingAs(
+            $this->user
+        );
+
+        $voucherSet         = VoucherSet::factory()->createQuietly();
+        $voucherSetMerchant = VoucherSetMerchantTeam::factory()->createQuietly(
+            [
+                'voucher_set_id'   => $voucherSet->id,
+                'merchant_team_id' => $this->user->current_team_id,
+            ]
+        );
+
+        $payload = [
+            'type'  => 'voucher_id',
+            'value' => 'INCORRECT VALUE',
+        ];
+
+        $data = json_encode($payload);
+
+        $response = $this->postJson($this->apiRoot . $this->endPoint, $payload);
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function itFailsIfVoucherIsExpired()
+    {
+
+        $this->user = $this->createUserWithTeam();
+
+        Sanctum::actingAs(
+            $this->user
+        );
+
+        $voucherSet         = VoucherSet::factory()->createQuietly();
+        $voucherSetMerchant = VoucherSetMerchantTeam::factory()->createQuietly(
+            [
+                'voucher_set_id'   => $voucherSet->id,
+                'merchant_team_id' => $this->user->current_team_id,
+            ]
+        );
+
+        $voucher = Voucher::factory()->create(
+            [
+                'voucher_set_id' => $voucherSet->id,
+                'expires_at'     => now()->subMonth(),
+            ]
+        );
+
+        $payload = [
+            'type'  => 'voucher_id',
+            'value' => $voucher->id,
+        ];
+
+        $response = $this->postJson($this->apiRoot . $this->endPoint, $payload);
+
+        $responseObject = json_decode($response->getContent());
+
+        /**
+         * Assert status code & message are expected
+         */
+        $response->assertStatus(409);
+        $this->assertEquals($responseObject->meta->message, ApiResponse::RESPONSE_REDEMPTION_FAILED_VOUCHER_EXPIRED->value);
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #111 

- Updated endpoint to return a 409 with the correct message string
- Added test also to handle business logic
- Updated enum case name to better describe the response message