### PR TITLE
Fix branded voucher card generation for Intervention Image v4

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(php artisan test --filter=calculateVoucherAmountRemainingReturnsNegativeWhenOverRedeemed)",
+      "Bash(php artisan test tests/Unit/Services/VoucherServiceTest.php)",
+      "Bash(git status:*)",
+      "Bash(gh pr create:*)",
+      "Bash(git remote:*)",
+      "Bash(git push:*)",
+      "Bash(gh auth:*)",
+      "Bash(gh issue:*)",
+      "Bash(php artisan:*)",
+      "Bash(composer show:*)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); pkgs=[p for p in d['packages'] if 'intervention/image' in p['name']]; [print\\(p['name'], p['version']\\) for p in pkgs]\")"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/app/Services/VoucherTemplateService.php
+++ b/app/Services/VoucherTemplateService.php
@@ -23,7 +23,7 @@ class VoucherTemplateService
 
     public static function generateWorkingVoucherTemplate(VoucherTemplate $voucherTemplate): void
     {
-        $img1 = Image::read(public_path('img/example-qr.png')); // The QR
+        $img1 = Image::decode(public_path('img/example-qr.png')); // The QR
 
         $img1->resize($voucherTemplate->voucher_qr_size_px, $voucherTemplate->voucher_qr_size_px);
 
@@ -34,10 +34,10 @@ class VoucherTemplateService
 
         // open an image file
 
-        $img = Image::read($img);
+        $img = Image::decode($img);
 
         // and insert the QR code
-        $img->place($img1, 'top-left', $voucherTemplate->voucher_qr_x, $voucherTemplate->voucher_qr_y);
+        $img->insert($img1, $voucherTemplate->voucher_qr_x, $voucherTemplate->voucher_qr_y);
 
         $code = 'AB1234';
 
@@ -78,17 +78,17 @@ class VoucherTemplateService
         $img = Storage::get($voucherTemplate->voucher_template_path);
 
         // open an image file
-        $img = Image::read($img);
+        $img = Image::decode($img);
 
         $qrCodeData = Storage::get('voucher-sets/' . $voucher->voucher_set_id . '/vouchers/all/png/' . $voucher->id . '.png');
 
-        $qrCode = Image::read($qrCodeData); // The QR
+        $qrCode = Image::decode($qrCodeData); // The QR
         $qrCode->resize($voucherTemplate->voucher_qr_size_px, $voucherTemplate->voucher_qr_size_px);
 
         /**
          * Place the QR code
          */
-        $img->place($qrCode, 'top-left', $voucherTemplate->voucher_qr_x, $voucherTemplate->voucher_qr_y);
+        $img->insert($qrCode, $voucherTemplate->voucher_qr_x, $voucherTemplate->voucher_qr_y);
 
         if (!isset($voucher->voucher_short_code) || is_null($voucher->voucher_short_code)) {
             Log::error('generateVoucherTemplate: No voucher_short_code exists for voucher #' . $voucher->id);
@@ -255,7 +255,6 @@ class VoucherTemplateService
          * Clean up
          */
         $image->clear();
-        $image->destroy();
 
         /**
          * Ensure the PDF is generated

--- a/tests/Unit/Services/VoucherTemplateServiceTest.php
+++ b/tests/Unit/Services/VoucherTemplateServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Voucher;
+use App\Models\VoucherSet;
+use App\Models\VoucherTemplate;
+use App\Services\VoucherTemplateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Encoders\PngEncoder;
+use Intervention\Image\Laravel\Facades\Image;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class VoucherTemplateServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function itGeneratesVoucherTemplateForVoucher(): void
+    {
+        Storage::fake();
+
+        $templateImagePath = 'teams/1/voucher-templates/template.png';
+
+        // Create a real 100x100 PNG image for the template
+        $templateImage = Image::createImage(100, 100);
+        Storage::put($templateImagePath, (string) $templateImage->encode(new PngEncoder()));
+
+        $voucherTemplate = VoucherTemplate::factory()->create([
+            'voucher_template_path'         => $templateImagePath,
+            'voucher_example_template_path' => $templateImagePath . '.example.png',
+            'overlay_font_path'             => 'fonts/Roboto-Regular.ttf',
+            'voucher_qr_size_px'            => 50,
+            'voucher_qr_x'                  => 10,
+            'voucher_qr_y'                  => 10,
+            'voucher_code_size_px'          => 16,
+            'voucher_code_x'                => 10,
+            'voucher_code_y'                => 70,
+            'voucher_code_prefix'           => 'Code:',
+            'voucher_expiry_size_px'        => 16,
+            'voucher_expiry_x'              => 10,
+            'voucher_expiry_y'              => 80,
+            'voucher_expiry_prefix'         => 'Expiry:',
+            'voucher_value_size_px'         => 16,
+            'voucher_value_x'              => 10,
+            'voucher_value_y'              => 90,
+            'voucher_value_prefix'          => '$',
+        ]);
+
+        $voucherSet = VoucherSet::factory()->create([
+            'voucher_template_id' => $voucherTemplate->id,
+            'expires_at'          => now()->addYear(),
+        ]);
+
+        $voucher = Voucher::factory()->create([
+            'voucher_set_id'         => $voucherSet->id,
+            'voucher_short_code'     => 'AB1234',
+            'voucher_value_original' => 5000,
+        ]);
+
+        // Create a QR code PNG in the expected storage path
+        $qrImage = Image::createImage(100, 100);
+        $qrPath = 'voucher-sets/' . $voucherSet->id . '/vouchers/all/png/' . $voucher->id . '.png';
+        Storage::put($qrPath, (string) $qrImage->encode(new PngEncoder()));
+
+        VoucherTemplateService::generateVoucherTemplate(
+            voucherTemplate: $voucherTemplate,
+            voucher: $voucher,
+        );
+
+        // Verify branded files were created
+        $brandedAllPath = '/voucher-sets/' . $voucherSet->id . '/vouchers/all/branded/' . $voucher->id . '.png';
+        $brandedIndividualPath = '/voucher-sets/' . $voucherSet->id . '/vouchers/individual/' . $voucher->id . '/branded/voucher-branded.png';
+
+        Storage::assertExists($brandedAllPath);
+        Storage::assertExists($brandedIndividualPath);
+    }
+
+    #[Test]
+    public function itGeneratesWorkingVoucherTemplate(): void
+    {
+        Storage::fake();
+
+        $templateImagePath = 'teams/1/voucher-templates/template.png';
+
+        $templateImage = Image::createImage(100, 100);
+        Storage::put($templateImagePath, (string) $templateImage->encode(new PngEncoder()));
+
+        $voucherTemplate = VoucherTemplate::factory()->create([
+            'voucher_template_path'         => $templateImagePath,
+            'voucher_example_template_path' => $templateImagePath . '.example.png',
+            'overlay_font_path'             => 'fonts/Roboto-Regular.ttf',
+            'voucher_qr_size_px'            => 50,
+            'voucher_qr_x'                  => 10,
+            'voucher_qr_y'                  => 10,
+            'voucher_code_size_px'          => 16,
+            'voucher_code_x'                => 10,
+            'voucher_code_y'                => 70,
+            'voucher_code_prefix'           => 'Code:',
+            'voucher_expiry_size_px'        => 16,
+            'voucher_expiry_x'              => 10,
+            'voucher_expiry_y'              => 80,
+            'voucher_expiry_prefix'         => 'Expiry:',
+            'voucher_value_size_px'         => 16,
+            'voucher_value_x'              => 10,
+            'voucher_value_y'              => 90,
+            'voucher_value_prefix'          => '$',
+        ]);
+
+        VoucherTemplateService::generateWorkingVoucherTemplate(
+            voucherTemplate: $voucherTemplate,
+        );
+
+        Storage::assertExists($voucherTemplate->voucher_example_template_path);
+    }
+}


### PR DESCRIPTION
## Summary
- Updated `VoucherTemplateService` to use Intervention Image v4 API methods (`Image::decode()` instead of `Image::read()`, `insert()` instead of `place()`)
- Added unit tests for `VoucherTemplateService` covering both `generateVoucherTemplate` and `generateWorkingVoucherTemplate`

## Context
Branded voucher cards were failing silently on the queue because the codebase was using Intervention Image v3 method names (`read()`, `place()`) after upgrading to v4. The plain QR codes generated fine since they use a different library, but the branded template overlay step threw `Call to undefined method Intervention\Image\ImageManager::read()`.

## Test plan
- [x] `VoucherTemplateServiceTest` passes (2 tests, 3 assertions)
- [ ] Deploy and re-run `app:regenerate-voucher-set-qr-codes-command` for affected voucher set
- [ ] Verify branded voucher images appear in S3 storage paths